### PR TITLE
Bump go version to 1.16 to support M1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
       -
         name: Import GPG key
         id: import_gpg

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,7 @@ builds:
     - darwin
   goarch:
     - amd64
+    - arm64
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip


### PR DESCRIPTION
This should allow us to support darwin_arm64 builds

Signed-off-by: João Soares <jsoaresgeral@gmail.com>